### PR TITLE
Makes test pass on Windows

### DIFF
--- a/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
+++ b/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
@@ -102,8 +102,8 @@ class CheckIfTranslationsAreAllThereCommand extends Command
             foreach ($languages as $language) {
 	
 				$fileKey = basename($key);
-	
-				$exists = array_key_exists($directory . '/' .  $language . '/' . $fileKey, $this->realLines);
+
+				$exists = array_key_exists($directory . DIRECTORY_SEPARATOR .  $language . DIRECTORY_SEPARATOR . $fileKey, $this->realLines);
 
                 if ($this->isDirInExcludedDirectories($language)) {
                     continue;

--- a/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
+++ b/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
@@ -79,7 +79,7 @@ class CheckIfTranslationsAreAllThereCommand extends Command
         foreach (new RecursiveIteratorIterator($rdi, RecursiveIteratorIterator::SELF_FIRST) as $langFile => $info) {
 
             if (!File::isDirectory($langFile) && !Str::endsWith($langFile, '.txt')) {
-                $fileName = Str::afterLast($langFile, "/");
+                $fileName = basename($langFile);
                 $languageDir = Str::replace($fileName, "", $langFile);
 
                 $languagesWithMissingFile = $this->checkIfFileExistsForOtherLanguages($languages, $fileName, $directory);
@@ -101,7 +101,7 @@ class CheckIfTranslationsAreAllThereCommand extends Command
 
             foreach ($languages as $language) {
 	
-				$fileKey = Str::afterLast($key, "/");
+				$fileKey = basename($key);
 	
 				$exists = array_key_exists($directory . '/' .  $language . '/' . $fileKey, $this->realLines);
 
@@ -134,7 +134,7 @@ class CheckIfTranslationsAreAllThereCommand extends Command
     {
         $lines = include($langFile);
 
-        $fileName = Str::afterLast($langFile, "/");
+        $fileName = basename($langFile);
 
         foreach ($lines as $index => $line) {
             if (is_array($line)) {


### PR DESCRIPTION
Using the basename function I get  `"test.php"`
Using Str::afterLast($str, '/') gets this: `"one_missing_key\en\test.php"`

That's because the directory separator is different on Windows.

Which is also the reason none of the test pass for me, I assume.