### PR TITLE
Fix crashing when encountered empty file

### DIFF
--- a/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
+++ b/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
@@ -141,6 +141,11 @@ class CheckIfTranslationsAreAllThereCommand extends Command
             $lines = include($langFile);
         }
 
+        if (!is_array($lines)) {
+            $this->warn("Failed to resolve file: " . $langFile);
+            return;
+        }
+
         foreach ($lines as $index => $line) {
             if (is_array($line)) {
                 foreach ($line as $index2 => $line2) {

--- a/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
+++ b/src/Console/Commands/CheckIfTranslationsAreAllThereCommand.php
@@ -142,7 +142,7 @@ class CheckIfTranslationsAreAllThereCommand extends Command
         }
 
         if (!is_array($lines)) {
-            $this->warn("Failed to resolve file: " . $langFile);
+            $this->warn("Skipping file (" . $langFile . ") because it is empty.");
             return;
         }
 


### PR DESCRIPTION
If language file is empty program crashes. This fixes the issue by skipping file.